### PR TITLE
Change ESLint comma-dangle to always-multiline, except for function args

### DIFF
--- a/assets/js/.eslintrc.json
+++ b/assets/js/.eslintrc.json
@@ -9,7 +9,15 @@
 		"array-callback-return": "error",
 		"block-spacing": "error",
 		"camelcase": "error",
-		"comma-dangle": "error",
+		"comma-dangle": [
+			"error", {
+				"arrays": "always-multiline",
+				"objects": "always-multiline",
+				"imports": "always-multiline",
+				"exports": "always-multiline",
+				"functions": "never"
+			}
+		],
 		"comma-spacing": "error",
 		"curly": "error",
 		"eol-last": "error",

--- a/assets/js/analyzer.js
+++ b/assets/js/analyzer.js
@@ -74,7 +74,7 @@ function getAnalyzers() /*: JQueryPromise<any> */ {
                 complete: function () {
                     ajaxComplete();
                     deferred.resolve();
-                }
+                },
             });
         }
     }
@@ -167,14 +167,14 @@ function analyze() {
     currentAnalyzerRequest = callApy({
         data: {
             'lang': analyzerMode,
-            'q': input
+            'q': input,
         },
         success: handleAnalyzeSuccessResponse,
         error: handleAnalyzeErrorResponse,
         complete: function () {
             ajaxComplete();
             currentAnalyzerRequest = null;
-        }
+        },
     }, '/analyze');
 }
 

--- a/assets/js/generator.js
+++ b/assets/js/generator.js
@@ -74,7 +74,7 @@ function getGenerators() /*: JQueryPromise<any> */ {
                 complete: function (_xOptions, _errorThrown) {
                     ajaxComplete();
                     deferred.resolve();
-                }
+                },
             });
         }
     }
@@ -167,14 +167,14 @@ function generate() {
     currentGeneratorRequest = callApy({
         data: {
             'lang': generatorMode,
-            'q': input
+            'q': input,
         },
         success: handleGenerateSuccessResponse,
         error: handleGenerateErrorResponse,
         complete: function () {
             ajaxComplete();
             currentGeneratorRequest = null;
-        }
+        },
     }, '/generate');
 }
 

--- a/assets/js/init.js
+++ b/assets/js/init.js
@@ -12,7 +12,7 @@ $(document).ajaxComplete(ajaxComplete);
 $(document).ajaxError(ajaxComplete);
 
 $.jsonp.setup({
-    callbackParameter: 'callback'
+    callbackParameter: 'callback',
 });
 
 $(document).ready(function () {
@@ -120,7 +120,7 @@ $(document).ready(function () {
 
     $('#backToTop').click(function () {
         $('html, body').animate({
-            scrollTop: 0
+            scrollTop: 0,
         }, 'fast');
         return false;
     });

--- a/assets/js/localization.js
+++ b/assets/js/localization.js
@@ -21,8 +21,8 @@ var dynamicLocalizations /*: {[lang: string]: {[string]: string}} */ = {
         'detected': 'detected',
         'File_Too_Large': 'File is too large!',
         'Format_Not_Supported': 'Format not supported!',
-        'Download_File': 'Download {{fileName}}'
-    }
+        'Download_File': 'Download {{fileName}}',
+    },
 };
 
 function getDynamicLocalization(stringKey /*: string */) /*: string */ {
@@ -167,7 +167,7 @@ function getLocale() {
                 complete: function (_xOptions, _errorThrown) {
                     ajaxComplete();
                     deferred.resolve();
-                }
+                },
             });
         }
         else {
@@ -207,7 +207,7 @@ function getLocales() {
                 error: function (jqXHR, textStatus, error) {
                     console.error('Failed to fetch available locales: ' + error);
                     deferred.resolve();
-                }
+                },
             });
         }
     }
@@ -287,7 +287,7 @@ function localizeLanguageNames(localizedNamesFromJSON) {
                 },
                 error: function (_xOptions, _error) {
                     localizedLanguageNames = {};
-                }
+                },
             });
         }
     }
@@ -336,7 +336,7 @@ function localizeStrings(stringsFresh /*: boolean */) {
                 },
                 error: function (jqXHR, textStatus, errorThrow) {
                     console.error('Failed to fetch localized strings for ' + locale + ': ' + errorThrow);
-                }
+                },
             });
         }
     }
@@ -385,7 +385,7 @@ function localizeInterface() {
         '#originalText': curSrcLang,
         '#translatedText': curDstLang,
         '#morphAnalyzerInput': $('#primaryAnalyzerMode').val(),
-        '#morphGeneratorInput': $('#primaryGeneratorMode').val()
+        '#morphGeneratorInput': $('#primaryGeneratorMode').val(),
     };
 
     $.each(elements, function (selector, lang /*: string */) {

--- a/assets/js/persistence.js
+++ b/assets/js/persistence.js
@@ -14,7 +14,7 @@ var URL_PARAM_Q_LIMIT = 1300,
         '#webpageTranslation': 'qP',
         '#analyzation': 'qA',
         '#generation': 'qG',
-        '#sandbox': 'qS'
+        '#sandbox': 'qS',
     };
 
 var store = new Store(config.HTML_URL);
@@ -57,31 +57,31 @@ function persistChoices(mode /*: string */, updatePermalink /*: ?boolean */) {
                 'webpageInput': $('#webpage').val(),
                 'instantTranslation': $('#instantTranslation').prop('checked'),
                 'markUnknown': $('#markUnknown').prop('checked'),
-                'chainedTranslation': $('#chainedTranslation').prop('checked')
+                'chainedTranslation': $('#chainedTranslation').prop('checked'),
             };
         }
         else if(mode === 'analyzer') {
             objects = {
                 'primaryAnalyzerChoice': $('#primaryAnalyzerMode').val(),
                 'secondaryAnalyzerChoice': $('#secondaryAnalyzerMode').val(),
-                'analyzerInput': $('#morphAnalyzerInput').val()
+                'analyzerInput': $('#morphAnalyzerInput').val(),
             };
         }
         else if(mode === 'generator') {
             objects = {
                 'primaryGeneratorChoice': $('#primaryGeneratorMode').val(),
                 'secondaryGeneratorChoice': $('#secondaryGeneratorMode').val(),
-                'generatorInput': $('#morphGeneratorInput').val()
+                'generatorInput': $('#morphGeneratorInput').val(),
             };
         }
         else if(mode === 'localization') {
             objects = {
-                'locale': $('.localeSelect').val()
+                'locale': $('.localeSelect').val(),
             };
         }
         else if(mode === 'sandbox') {
             objects = {
-                'sandboxInput': $('#sandboxInput').val()
+                'sandboxInput': $('#sandboxInput').val(),
             };
         }
 

--- a/assets/js/sandbox.js
+++ b/assets/js/sandbox.js
@@ -53,7 +53,7 @@ function request() {
             ajaxComplete();
             $('#time').text(new Date().getTime() - startTime + ' ms');
             currentSandboxRequest = null;
-        }
+        },
     });
 }
 

--- a/assets/js/translator.js
+++ b/assets/js/translator.js
@@ -79,7 +79,7 @@ if(modeEnabled('translation')) {
 
                 $('input#webpage').attr({
                     'required': false,
-                    'novalidate': true
+                    'novalidate': true,
                 });
 
                 $('div#translateWebpage').fadeOut('fast', function () {
@@ -404,7 +404,7 @@ function getPairs() /*: JQueryPromise<any> */ {
                 complete: function (_xOptions, _errorThrown) {
                     ajaxComplete();
                     deferred.resolve();
-                }
+                },
             });
         }
     }
@@ -806,7 +806,7 @@ function translateText(ignoreIfEmpty) {
             var endpoint/*: string */;
             var request /*: { langpairs?: string, langpair?: string, q: string, markUnknown: string } */ = {
                 q: originalText, // eslint-disable-line id-length
-                markUnknown: $('#markUnknown').prop('checked') ? 'yes' : 'no'
+                markUnknown: $('#markUnknown').prop('checked') ? 'yes' : 'no',
             };
 
             if($('input#chainedTranslation').prop('checked') && config.TRANSLATION_CHAINING) {
@@ -825,7 +825,7 @@ function translateText(ignoreIfEmpty) {
                 complete: function () {
                     ajaxComplete();
                     translateRequest = null;
-                }
+                },
             }, endpoint);
         }
         else {
@@ -858,7 +858,7 @@ function translateDoc() {
                 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
                 // 'application/msword', 'application/vnd.ms-powerpoint', 'application/vnd.ms-excel'
                 'application/vnd.oasis.opendocument.text',
-                'application/x-latex', 'application/x-tex'
+                'application/x-latex', 'application/x-tex',
             ];
 
             if(allowedMimeTypes.indexOf(file.type) !== -1) {
@@ -1059,7 +1059,7 @@ function translateWebpage(ignoreIfEmpty /*: ?boolean */) {
             data: {
                 'langpair': curSrcLang + '|' + curDstLang,
                 'markUnknown': 'no',
-                'url': url
+                'url': url,
             },
             dataType: 'json',
             success: handleTranslateWebpageSuccessResponse,
@@ -1068,7 +1068,7 @@ function translateWebpage(ignoreIfEmpty /*: ?boolean */) {
                 ajaxComplete();
                 translateRequest = null;
                 $('iframe#translatedWebpage').animate({'opacity': 1}, 'fast');
-            }
+            },
         }, '/translatePage', true);
     }
 }
@@ -1079,7 +1079,7 @@ function showTranslateWebpageInterface(url /*: ?string */, ignoreIfEmpty /*: ?bo
     $('div#translateText').fadeOut('fast', function () {
         $('input#webpage').attr({
             'required': true,
-            'novalidate': false
+            'novalidate': false,
         });
         $('button#cancelTranslateWebpage').fadeIn('fast').addClass('cancelTranslateWebpage');
         $('div#translateWebpage').fadeIn('fast');
@@ -1136,14 +1136,14 @@ function detectLanguage() {
 
     translateRequest = callApy({
         data: {
-            'q': originalText
+            'q': originalText,
         },
         success: handleDetectLanguageSuccessResponse,
         error: handleDetectLanguageErrorResponse,
         complete: function () {
             ajaxComplete();
             translateRequest = null;
-        }
+        },
     }, '/identifyLang');
 
     return translateRequest;

--- a/assets/js/util.js
+++ b/assets/js/util.js
@@ -209,7 +209,7 @@ function synchronizeTextareaHeights() {
 
     $('#originalText').css({
         'overflow-y': 'hidden',
-        'height': 'auto'
+        'height': 'auto',
     });
     var originalTextScrollHeight = $('#originalText')[0].scrollHeight;
     $('#originalText').css('height', originalTextScrollHeight + 'px');
@@ -220,7 +220,7 @@ function callApy(options /*: {} */, endpoint /*: string */, useAjax /*: ?boolean
     var requestOptions /*: any */ = Object.assign({
         url: config.APY_URL + endpoint,
         beforeSend: ajaxSend,
-        contentType: 'application/x-www-form-urlencoded; charset=UTF-8'
+        contentType: 'application/x-www-form-urlencoded; charset=UTF-8',
     }, options);
 
     var requestUrl /*: string */ = window.location.protocol + window.location.hostname +


### PR DESCRIPTION
The diff from https://github.com/apertium/apertium-html-tools/pull/400 has superfluous line changes, which made me realize this project enforces no trailing commas. So change that to enforce trailing commas, except for function args, as this reduces diff overhead and copy-paste errors. It is a travesty that JSON doesn't allow trailing commas, but we should absolutely require it for all JS lists.