### PR TITLE
Target ES2019 (fixes #417)

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -189,6 +189,7 @@ void esbuild.build({
   entryPoints: ['src/index.tsx'],
   bundle: true,
   metafile: true,
+  target: 'es2019',
   loader: { '.embed.png': 'dataurl', '.png': 'file', '.gif': 'file', '.jpg': 'file' },
   outdir: 'dist',
   plugins: [Plugin],


### PR DESCRIPTION
As per https://esbuild.github.io/api/#target default is `esnext` which is way too new. Target should be $YEAR - 5, currently ES2016.