### PR TITLE
Rewrite navbar layout

### DIFF
--- a/src/components/LocaleSelector.tsx
+++ b/src/components/LocaleSelector.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import classNames from 'classnames';
 import { faGlobe } from '@fortawesome/free-solid-svg-icons';
 import { useMatomo } from '@datapunt/matomo-tracker-react';
 
@@ -12,8 +13,10 @@ const height = '1.5rem';
 const LocaleSelector = ({
   setLocale,
   inverse,
+  className = '',
 }: {
   inverse?: boolean;
+  className?: string;
   setLocale: React.Dispatch<React.SetStateAction<string>>;
 }): React.ReactElement => {
   const locale = React.useContext(LocaleContext);
@@ -28,7 +31,7 @@ const LocaleSelector = ({
   );
 
   return (
-    <div className="mt-2" style={{ height }}>
+    <div className={classNames('mt-2', className)} style={{ height }}>
       <FontAwesomeIcon className="float-right ml-2" icon={faGlobe} inverse={inverse} style={{ fontSize: height }} />
       {/* eslint-disable-next-line jsx-a11y/no-onchange */}
       <select className="float-right h-100" onChange={onChange} style={{ fontSize: '0.9rem' }} value={locale}>

--- a/src/components/navbar/__tests__/index.test.tsx
+++ b/src/components/navbar/__tests__/index.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { MemoryHistory, MemoryHistoryBuildOptions, createMemoryHistory } from 'history';
-import { getAllByRole, queryAllByRole, render, screen } from '@testing-library/react';
+import { getAllByRole, getByText, queryAllByRole, render, screen, within } from '@testing-library/react';
 import { Router } from 'react-router-dom';
 import userEvent from '@testing-library/user-event';
 
@@ -24,30 +24,53 @@ const renderNavbar = (options?: MemoryHistoryBuildOptions, config: Partial<Confi
   return history;
 };
 
+const withinMobileNavbar = () => within(screen.getByTestId('navbar-mobile'));
+
 describe('navigation options', () => {
   it('includes links per mode', () => {
     renderNavbar();
 
-    const navbar = screen.getByRole('navigation');
-    const buttons = getAllByRole(navbar, 'link', { name: (n) => n !== 'Toggle navigation' });
+    const navbar = screen.getByTestId('navbar-mobile');
+    const links = getAllByRole(navbar, 'link', { name: (n) => n !== 'Toggle navigation' });
 
-    expect(buttons).toHaveLength(4);
+    expect(links).toHaveLength(4);
   });
 
-  it('hides button when only one mode is enabled', () => {
-    renderNavbar(undefined, { enabledModes: new Set([Mode.Translation]) });
+  it('includes button', () => {
+    renderNavbar();
 
-    const navbar = screen.getByRole('navigation');
-    const buttons = queryAllByRole(navbar, 'link');
+    const navbar = screen.getByTestId('navbar-mobile');
+    const buttons = queryAllByRole(navbar, 'button');
 
     expect(buttons).toHaveLength(0);
+  });
+
+  describe('with only one mode enabled', () => {
+    it('hides links', () => {
+      renderNavbar(undefined, { enabledModes: new Set([Mode.Translation]) });
+
+      const navbar = screen.getByRole('navigation');
+      const links = queryAllByRole(navbar, 'link');
+
+      expect(links).toHaveLength(0);
+    });
+
+    it('hides button', () => {
+      renderNavbar(undefined, { enabledModes: new Set([Mode.Translation]) });
+
+      const navbar = screen.getByRole('navigation');
+      const buttons = queryAllByRole(navbar, 'button');
+
+      expect(buttons).toHaveLength(0);
+    });
   });
 });
 
 it('defaults to translation', () => {
   renderNavbar();
 
-  expect(screen.getByText('Translation-Default').className).toContain('active');
+  const navbar = screen.getByTestId('navbar-mobile');
+  expect(getByText(navbar, 'Translation-Default').className).toContain('active');
 });
 
 describe('subtitle', () => {
@@ -73,12 +96,12 @@ describe('subtitle', () => {
 describe('translation navigation', () => {
   it.each(['/translation', '/webpageTranslation', '/docTranslation'])('shows active link for %s', (pathname) => {
     renderNavbar({ initialEntries: [pathname] });
-    expect(screen.getByText('Translation-Default').className).toContain('active');
+    expect(withinMobileNavbar().getByText('Translation-Default').className).toContain('active');
   });
 
   it('navigates on button click', () => {
     const history = renderNavbar();
-    userEvent.click(screen.getByText('Translation-Default'));
+    userEvent.click(withinMobileNavbar().getByText('Translation-Default'));
     expect(history.location.pathname).toEqual('/translation');
   });
 });
@@ -86,12 +109,12 @@ describe('translation navigation', () => {
 describe('analysis navigation', () => {
   it('shows an active link', () => {
     renderNavbar({ initialEntries: ['/analysis'] });
-    expect(screen.getByText('Morphological_Analysis-Default').className).toContain('active');
+    expect(withinMobileNavbar().getByText('Morphological_Analysis-Default').className).toContain('active');
   });
 
   it('navigates on button click', () => {
     const history = renderNavbar();
-    userEvent.click(screen.getByText('Morphological_Analysis-Default'));
+    userEvent.click(withinMobileNavbar().getByText('Morphological_Analysis-Default'));
     expect(history.location.pathname).toEqual('/analysis');
   });
 });
@@ -99,12 +122,12 @@ describe('analysis navigation', () => {
 describe('generation navigation', () => {
   it('shows an active link', () => {
     renderNavbar({ initialEntries: ['/generation'] });
-    expect(screen.getByText('Morphological_Generation-Default').className).toContain('active');
+    expect(withinMobileNavbar().getByText('Morphological_Generation-Default').className).toContain('active');
   });
 
   it('navigates on button click', () => {
     const history = renderNavbar();
-    userEvent.click(screen.getByText('Morphological_Generation-Default'));
+    userEvent.click(withinMobileNavbar().getByText('Morphological_Generation-Default'));
     expect(history.location.pathname).toEqual('/generation');
   });
 });
@@ -112,12 +135,12 @@ describe('generation navigation', () => {
 describe('sandbox navigation', () => {
   it('shows an active link', () => {
     renderNavbar({ initialEntries: ['/sandbox'] });
-    expect(screen.getByText('APy_Sandbox-Default').className).toContain('active');
+    expect(withinMobileNavbar().getByText('APy_Sandbox-Default').className).toContain('active');
   });
 
   it('navigates on button click', () => {
     const history = renderNavbar();
-    userEvent.click(screen.getByText('APy_Sandbox-Default'));
+    userEvent.click(withinMobileNavbar().getByText('APy_Sandbox-Default'));
     expect(history.location.pathname).toEqual('/sandbox');
   });
 });

--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -1,10 +1,10 @@
 import './navbar.css';
 
 import * as React from 'react';
+import Nav, { NavProps } from 'react-bootstrap/Nav';
 import BootstrapNavbar from 'react-bootstrap/Navbar';
 import Container from 'react-bootstrap/Container';
 import { LinkContainer } from 'react-router-bootstrap';
-import Nav from 'react-bootstrap/Nav';
 
 import { ConfigContext } from '../../context';
 import { Path as DocTranslationPath } from '../translator/DocTranslationForm';
@@ -36,11 +36,11 @@ const TagLine = (): React.ReactElement => {
 
   return (
     <p
+      className="mb-0"
       style={{
         color: '#fff',
         fontSize: '18px',
         fontWeight: 'bold',
-        margin: '0 0 10px',
       }}
     >
       {t('tagline')}
@@ -48,7 +48,7 @@ const TagLine = (): React.ReactElement => {
   );
 };
 
-const NavbarNav: React.ComponentType = () => {
+const NavbarNav: React.ComponentType = (props: NavProps) => {
   const { t } = useLocalization();
   const { enabledModes, defaultMode } = React.useContext(ConfigContext);
 
@@ -57,9 +57,9 @@ const NavbarNav: React.ComponentType = () => {
   }
 
   return (
-    <Nav activeKey={undefined} as="ul" className="mt-1 ml-auto">
+    <Nav {...props} activeKey={undefined} as="ul" className="ml-auto">
       {enabledModes.has(Mode.Translation) && (
-        <Nav.Item as="li" className="p-1">
+        <Nav.Item as="li">
           <LinkContainer
             isActive={(_, { pathname }) =>
               [TextTranslationPath, WebpageTranslationPath, DocTranslationPath].includes(pathname) ||
@@ -72,7 +72,7 @@ const NavbarNav: React.ComponentType = () => {
         </Nav.Item>
       )}
       {enabledModes.has(Mode.Analysis) && (
-        <Nav.Item as="li" className="p-1">
+        <Nav.Item as="li">
           <LinkContainer
             isActive={(_, { pathname }) =>
               pathname === '/analysis' || (pathname === '/' && defaultMode === Mode.Analysis)
@@ -84,7 +84,7 @@ const NavbarNav: React.ComponentType = () => {
         </Nav.Item>
       )}
       {enabledModes.has(Mode.Generation) && (
-        <Nav.Item as="li" className="p-1">
+        <Nav.Item as="li">
           <LinkContainer
             isActive={(_, { pathname }) =>
               pathname === '/generation' || (pathname === '/' && defaultMode === Mode.Generation)
@@ -96,7 +96,7 @@ const NavbarNav: React.ComponentType = () => {
         </Nav.Item>
       )}
       {enabledModes.has(Mode.Sandbox) && (
-        <Nav.Item as="li" className="p-1">
+        <Nav.Item as="li">
           <LinkContainer
             isActive={(_, { pathname }) =>
               pathname === '/sandbox' || (pathname === '/' && defaultMode === Mode.Sandbox)
@@ -112,35 +112,37 @@ const NavbarNav: React.ComponentType = () => {
 };
 
 const Navbar = ({ setLocale }: { setLocale: React.Dispatch<React.SetStateAction<string>> }): React.ReactElement => {
-  const { subtitle, subtitleColor } = React.useContext(ConfigContext);
+  const { subtitle, subtitleColor, enabledModes } = React.useContext(ConfigContext);
 
   return (
-    <BootstrapNavbar bg="dark" className="navbar navbar-default mb-4 pt-0" expand="md" variant="dark">
+    <BootstrapNavbar bg="dark" className="navbar navbar-default mb-4 pt-1" expand="md" variant="dark">
       <Container className="position-relative" style={{ lineHeight: '1.5em' }}>
-        <div>
+        <div className="d-flex justify-content-between w-100">
           <div>
-            <Logo />
-            {subtitle && (
-              <span className="apertium-sublogo" style={subtitleColor ? { color: subtitleColor } : {}}>
-                {subtitle}
-              </span>
-            )}
-            <span className="apertium-logo">Apertium</span>
+            <div>
+              <Logo />
+              {subtitle && (
+                <span className="apertium-sublogo" style={subtitleColor ? { color: subtitleColor } : {}}>
+                  {subtitle}
+                </span>
+              )}
+              <span className="apertium-logo">Apertium</span>
+            </div>
+            <div className="d-flex justify-content-between align-items-center">
+              <TagLine />
+              {enabledModes.size > 1 && <BootstrapNavbar.Toggle className="ml-3" />}
+            </div>
+            <div className="d-block d-md-none">
+              <BootstrapNavbar.Collapse>
+                <NavbarNav data-testid="navbar-mobile" />
+              </BootstrapNavbar.Collapse>
+            </div>
           </div>
-          <TagLine />
+          <div className="d-none d-md-flex flex-column justify-content-between align-self-stretch">
+            <LocaleSelector className="float-right" inverse setLocale={setLocale} />
+            <NavbarNav data-testid="navbar-desktop" />
+          </div>
         </div>
-        <div
-          className="float-right d-none d-md-block align-self-start"
-          style={{
-            width: '35%',
-          }}
-        >
-          <LocaleSelector inverse setLocale={setLocale} />
-        </div>
-        <BootstrapNavbar.Toggle />
-        <BootstrapNavbar.Collapse>
-          <NavbarNav />
-        </BootstrapNavbar.Collapse>
       </Container>
     </BootstrapNavbar>
   );

--- a/src/components/navbar/navbar.css
+++ b/src/components/navbar/navbar.css
@@ -1,36 +1,16 @@
-.navbar {
-  padding: 0.5rem 1rem;
+@media (min-width: 768px) {
+  .navbar .nav-link {
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+}
+
+html[dir='rtl'] .navbar-nav {
+  padding-inline-start: 1px;
 }
 
 .navbar .nav-link {
-  font-size: 16px;
-}
-
-@media (min-width: 768px) {
-  .collapse.navbar-collapse {
-    bottom: -30px;
-    position: absolute;
-    right: 0;
-  }
-
-  html[dir='rtl'] .collapse.navbar-collapse {
-    left: 0;
-    right: auto;
-  }
-
-  .navbar-default {
-    padding-bottom: 30px;
-  }
-}
-
-@media (min-width: 1200px) {
-  .collapse.navbar-collapse {
-    bottom: 0;
-  }
-
-  .navbar-default {
-    padding-bottom: 0;
-  }
+  font-size: 1rem;
 }
 
 @font-face {


### PR DESCRIPTION
Fixes https://github.com/apertium/apertium-html-tools/issues/451 and moves the collapse button to be horizontally aligned with the tagline rather than below it:

Before:
![image](https://user-images.githubusercontent.com/4211838/174502897-94b641c1-71db-4b5d-a917-aabe5996d2a2.png)


After:
![image](https://user-images.githubusercontent.com/4211838/174502893-f98fa7fe-65d1-4afc-90b8-33888320f3de.png)
