### PR TITLE
fixes #477 (Build should not rely on git)

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -63,7 +63,7 @@ const Plugin = {
   name: 'apertium-html-tools',
   setup: async ({ initialOptions, onEnd }: esbuild.PluginBuild) => {
     const version = `v${(packageJson as { version: string }).version}`;
-    
+
     let defaultStrings: unknown;
 
     let pairsResponse, analyzersResponse, generatorsResponse;

--- a/build.ts
+++ b/build.ts
@@ -1,4 +1,4 @@
-import * as child_process from 'child_process';
+import * as packageJson from './package.json';
 import * as path from 'path';
 import { promises as fs } from 'fs';
 
@@ -62,8 +62,8 @@ const allowedLang = (code: string): boolean => {
 const Plugin = {
   name: 'apertium-html-tools',
   setup: async ({ initialOptions, onEnd }: esbuild.PluginBuild) => {
-    const version = process.env.BUILD_VERSION || 'v' + require('./package.json').version;
-
+    const version = `v${(packageJson as { version: string }).version}`;
+    
     let defaultStrings: unknown;
 
     let pairsResponse, analyzersResponse, generatorsResponse;

--- a/build.ts
+++ b/build.ts
@@ -62,7 +62,7 @@ const allowedLang = (code: string): boolean => {
 const Plugin = {
   name: 'apertium-html-tools',
   setup: async ({ initialOptions, onEnd }: esbuild.PluginBuild) => {
-    const version = child_process.execSync('git describe --tags --always').toString().trim();
+    const version = process.env.BUILD_VERSION || 'v' + require('./package.json').version;
 
     let defaultStrings: unknown;
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Sushain Cherivirala <sushain@skc.name>",
   "license": "GPL-3.0-or-later",
   "scripts": {
-    "build": "ts-node build.ts",
+    "build": "BUILD_VERSION=$BUILD_VERSION ts-node build.ts",
     "serve": "python3 -m http.server --directory dist",
     "tsc": "tsc --noEmit",
     "eslint": "eslint . --ext .ts,.tsx --max-warnings 0",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "apertium-html-tools",
-  "version": "5.0.0",
+  "version": "5.1.8",
   "author": "Sushain Cherivirala <sushain@skc.name>",
   "license": "GPL-3.0-or-later",
   "scripts": {
-    "build": "BUILD_VERSION=$BUILD_VERSION ts-node build.ts",
+    "build": "ts-node build.ts",
     "serve": "python3 -m http.server --directory dist",
     "tsc": "tsc --noEmit",
     "eslint": "eslint . --ext .ts,.tsx --max-warnings 0",


### PR DESCRIPTION
fixes #477 

**Description :**

This pull request addresses the issue where the build process was relying on Git for version information. The problem arose when the build process did not have Git available.

**Changes Made :**

  -In package.json, updated the `version` field to the latest released GitHub version

 -In build.ts, modified the code to use the version specified in package.json.