### PR TITLE
 Improve swap lang button for language and text swapping

### DIFF
--- a/src/components/translator/LanguageSelector.tsx
+++ b/src/components/translator/LanguageSelector.tsx
@@ -28,6 +28,7 @@ export type Props = {
   tgtLang: string;
   setTgtLang: (code: string) => void;
   recentTgtLangs: Array<string>;
+  swapLangText: () => void;
 
   detectLangEnabled: boolean;
   detectedLang: string | null;
@@ -423,7 +424,17 @@ const DesktopLanguageSelector = ({
 };
 
 const LanguageSelector = (props: Props): React.ReactElement => {
-  const { pairs, srcLang, setSrcLang, recentSrcLangs, setRecentSrcLangs, tgtLang, setTgtLang, setDetectedLang } = props;
+  const {
+    pairs,
+    srcLang,
+    setSrcLang,
+    recentSrcLangs,
+    setRecentSrcLangs,
+    tgtLang,
+    setTgtLang,
+    setDetectedLang,
+    swapLangText,
+  } = props;
 
   const swapLangs = React.useMemo(
     () =>
@@ -431,9 +442,10 @@ const LanguageSelector = (props: Props): React.ReactElement => {
         ? () => {
             setSrcLang(tgtLang);
             setTgtLang(srcLang);
+            swapLangText();
           }
         : undefined,
-    [pairs, setSrcLang, setTgtLang, srcLang, tgtLang],
+    [pairs, setSrcLang, setTgtLang, srcLang, tgtLang, swapLangText],
   );
 
   const [detectingLang, setDetectingLang] = React.useState(false);

--- a/src/components/translator/TextTranslationForm.tsx
+++ b/src/components/translator/TextTranslationForm.tsx
@@ -11,11 +11,10 @@ import { useHistory } from 'react-router-dom';
 import { useMatomo } from '@datapunt/matomo-tracker-react';
 
 import { DetectCompleteEvent, DetectEvent, PairPrefValues, TranslateEvent, baseUrlParams } from '.';
-import { MaxURLLength, buildNewSearch, getUrlParam } from '../../util/url';
+import { MaxURLLength, buildNewSearch } from '../../util/url';
 import { APyContext } from '../../context';
 import { buildUrl as buildWebpageTranslationUrl } from './WebpageTranslationForm';
 import { langDirection } from '../../util/languages';
-import useLocalStorage from '../../util/useLocalStorage';
 import { useLocalization } from '../../util/localization';
 
 const textUrlParam = 'q';
@@ -36,6 +35,10 @@ export type Props = {
   markUnknown: boolean;
   pairPrefs: PairPrefValues;
   setLoading: (loading: boolean) => void;
+  srcText: string;
+  tgtText: string;
+  setSrcText: (text: string) => void;
+  setTgtText: (text: string) => void;
 };
 
 const TextTranslationForm = ({
@@ -45,6 +48,10 @@ const TextTranslationForm = ({
   instantTranslation,
   pairPrefs,
   setLoading,
+  srcText,
+  tgtText,
+  setSrcText,
+  setTgtText,
 }: Props): React.ReactElement => {
   const { t } = useLocalization();
   const history = useHistory();
@@ -53,11 +60,6 @@ const TextTranslationForm = ({
 
   const srcTextareaRef = React.useRef<HTMLTextAreaElement>(null);
   const tgtTextareaRef = React.useRef<HTMLTextAreaElement>(null);
-
-  const [srcText, setSrcText] = useLocalStorage('srcText', '', {
-    overrideValue: getUrlParam(history.location.search, textUrlParam),
-  });
-  const [tgtText, setTgtText] = React.useState('');
 
   React.useEffect(() => {
     const baseParams = baseUrlParams({ srcLang, tgtLang });
@@ -130,7 +132,7 @@ const TextTranslationForm = ({
         }
       })();
     },
-    [apyFetch, markUnknown, prefs, setLoading, srcLang, srcText, tgtLang, trackEvent],
+    [apyFetch, markUnknown, prefs, setLoading, setTgtText, srcLang, srcText, tgtLang, trackEvent],
   );
 
   const translationTimer = React.useRef<number | null>(null);

--- a/src/components/translator/Translator.tsx
+++ b/src/components/translator/Translator.tsx
@@ -243,11 +243,16 @@ const WithTgtLang = ({
 const Translator = ({ mode: initialMode }: { mode?: Mode }): React.ReactElement => {
   const mode: Mode = initialMode || Mode.Text;
 
+  const textUrlParam = 'q';
   const { t } = useLocalization();
   const history = useHistory();
   const config = React.useContext(ConfigContext);
 
   const [loading, setLoading] = React.useState(false);
+  const [srcText, setSrcText] = useLocalStorage('srcText', '', {
+    overrideValue: getUrlParam(history.location.search, textUrlParam),
+  });
+  const [tgtText, setTgtText] = React.useState('');
 
   const [markUnknown, setMarkUnknown] = useLocalStorage('markUnknown', false);
   const [instantTranslation, setInstantTranslation] = useLocalStorage('instantTranslation', true);
@@ -271,6 +276,11 @@ const Translator = ({ mode: initialMode }: { mode?: Mode }): React.ReactElement 
   }
 
   const onTranslate = React.useCallback(() => window.dispatchEvent(new Event(TranslateEvent)), []);
+
+  const swapLangText = () => {
+    setSrcText(tgtText);
+    setTgtText(srcText);
+  };
 
   return (
     <Form
@@ -307,12 +317,24 @@ const Translator = ({ mode: initialMode }: { mode?: Mode }): React.ReactElement 
                     tgtLang,
                     detectedLang,
                     loading,
+                    swapLangText,
                   }}
                 />
                 {(mode === Mode.Text || !mode) && (
                   <>
                     <TextTranslationForm
-                      {...{ instantTranslation, markUnknown, setLoading, srcLang, tgtLang, pairPrefs }}
+                      {...{
+                        instantTranslation,
+                        markUnknown,
+                        setLoading,
+                        srcLang,
+                        tgtLang,
+                        pairPrefs,
+                        srcText,
+                        tgtText,
+                        setSrcText,
+                        setTgtText,
+                      }}
                     />
                     <Row className="mt-2 mb-3">
                       <Col className="d-flex d-sm-block flex-wrap translation-modes" md="6" xs="12">

--- a/src/components/translator/__tests__/LanguageSelector.test.tsx
+++ b/src/components/translator/__tests__/LanguageSelector.test.tsx
@@ -23,6 +23,7 @@ const renderLanguageSelector = (props_: Partial<Props> = {}): Props => {
     detectLangEnabled: true,
     detectedLang: null,
     setDetectedLang: jest.fn(),
+    swapLangText: jest.fn(),
     ...props_,
   };
 
@@ -90,7 +91,7 @@ describe('swapping', () => {
   });
 
   it('allow swapping when swapped pair valid', () => {
-    const { srcLang, tgtLang, setSrcLang, setTgtLang } = renderLanguageSelector({
+    const { srcLang, tgtLang, setSrcLang, setTgtLang, swapLangText } = renderLanguageSelector({
       tgtLang: 'spa',
     });
 
@@ -98,6 +99,7 @@ describe('swapping', () => {
 
     expect(setSrcLang).toHaveBeenCalledWith(tgtLang);
     expect(setTgtLang).toHaveBeenCalledWith(srcLang);
+    expect(swapLangText).toHaveBeenCalled();
   });
 });
 

--- a/src/components/translator/__tests__/TextTranslationForm.test.tsx
+++ b/src/components/translator/__tests__/TextTranslationForm.test.tsx
@@ -7,6 +7,10 @@ import userEvent from '@testing-library/user-event';
 
 import { DetectCompleteEvent, DetectEvent, TranslateEvent } from '..';
 import TextTranslationForm, { Props } from '../TextTranslationForm';
+import { getUrlParam } from '../../../util/url';
+import useLocalStorage from '../../../util/useLocalStorage';
+
+const textUrlParam = 'q';
 
 const renderTextTranslationForm = (
   props_: Partial<Props> = {},
@@ -20,13 +24,34 @@ const renderTextTranslationForm = (
     srcLang: 'eng',
     tgtLang: 'spa',
     pairPrefs: {},
+    srcText: '',
+    tgtText: '',
+    setSrcText: jest.fn(),
+    setTgtText: jest.fn(),
     setLoading: jest.fn(),
     ...props_,
   };
 
+  const Wrapper = () => {
+    const [srcText, setSrcText] = useLocalStorage('srcText', '', {
+      overrideValue: getUrlParam(history.location.search, textUrlParam),
+    });
+    const [tgtText, setTgtText] = React.useState('');
+
+    return (
+      <TextTranslationForm
+        {...props}
+        setSrcText={setSrcText}
+        setTgtText={setTgtText}
+        srcText={srcText}
+        tgtText={tgtText}
+      />
+    );
+  };
+
   render(
     <Router history={history}>
-      <TextTranslationForm {...props} />
+      <Wrapper />
     </Router>,
   );
 
@@ -149,16 +174,31 @@ describe('translation', () => {
       srcLang: 'eng',
       tgtLang: 'spa',
       pairPrefs: {},
+      srcText: '',
+      tgtText: '',
+      setSrcText: jest.fn(),
+      setTgtText: jest.fn(),
       setLoading: jest.fn(),
     };
 
     const Container = () => {
       const [srcLang, setSrcLang] = React.useState('eng');
+      const [srcText, setSrcText] = useLocalStorage('srcText', '', {
+        overrideValue: getUrlParam(history.location.search, textUrlParam),
+      });
+      const [tgtText, setTgtText] = React.useState('');
       return (
         <>
           <button onClick={() => setSrcLang('cat')}>ChangeSrcLang</button>
           <Router history={history}>
-            <TextTranslationForm {...props} srcLang={srcLang} />
+            <TextTranslationForm
+              {...props}
+              setSrcText={setSrcText}
+              setTgtText={setTgtText}
+              srcLang={srcLang}
+              srcText={srcText}
+              tgtText={tgtText}
+            />
           </Router>
         </>
       );


### PR DESCRIPTION
fixes #469 

**Description :**

This pull request addresses the issue where switching languages doesn't copy already provided input and output. With the modified changes now  when  the languages are swapped the new input is our already provided output.

before : `https://beta.apertium.org/index.eng.html#?dir=eng-spa&q=Dog` to `https://beta.apertium.org/index.eng.html#?dir=spa-eng&q=Dog`

After : `https://beta.apertium.org/index.eng.html#?dir=eng-spa&q=Dog` to `https://beta.apertium.org/index.eng.html#?dir=spa-eng&q=Perro`

**Changes Made :**
 -Lifted state from the child component `TextTranslationForm` to the parent component `Translator`, passing the state and its corresponding setter functions as props and wrapped setSrcText and setTgtText in the function swapLangText to swap the text and passed it to LanguageSelector as a prop. Included that function in swapLangs function to call it whenever it is executed.

 -Modified `TextTranslationForm.test` to accommodate the new changes made to `TextTranslationForm`. In `LanguageSelector.test`, checked whether `swapLangText` is actually getting called or not.
