### PR TITLE
Added dividers between languages

### DIFF
--- a/src/components/translator/LanguageSelector.tsx
+++ b/src/components/translator/LanguageSelector.tsx
@@ -211,23 +211,28 @@ const LangsDropdown = ({
       const [code, name] = langs[j];
       const valid = !validLang || validLang(code);
       langElems.push(
-        <button
-          className={classNames('language-name', {
-            'variant-language-name': isVariant(code),
-            'text-muted': !valid,
-          })}
-          disabled={!valid}
-          key={code}
-          onClick={() => {
-            setLang(code);
-            document.body.click();
-          }}
-          tabIndex={0}
-        >
-          {name}
-        </button>,
+        <div>
+          <button
+            className={classNames('language-name', {
+              'variant-language-name': isVariant(code),
+              'text-muted': !valid,
+            })}
+            disabled={!valid}
+            key={code}
+            onClick={() => {
+              setLang(code);
+              document.body.click();
+            }}
+            tabIndex={0}
+          >
+            {name}
+          </button>
+
+          <div style={{ height: '0.5px', backgroundColor: 'gray', opacity: '30%' }} />
+        </div>,
       );
     }
+
     langCols.push(
       <div className="language-name-col" key={i} style={{ width: `${100.0 / numCols}%` }}>
         {langElems}


### PR DESCRIPTION
Hello!

This is my solution to the **Issue #441** 
I tried both options proposed by Jonathan and,

I think we should go with adding a **divider between languages** as it looks cleaner and clearer. Below is the screenshot for this solution

<img width="830" alt="Screenshot 2024-03-21 at 22 10 19" src="https://github.com/apertium/apertium-html-tools/assets/65281361/11f34add-9d9a-49fa-9666-698e45f83f10">

However, I think you should also take a look at how solution with divider looks like:

<img width="826" alt="Screenshot 2024-03-21 at 22 13 17" src="https://github.com/apertium/apertium-html-tools/assets/65281361/c041d0f3-ef2e-4219-be97-1803c662ba77">

